### PR TITLE
Delorean

### DIFF
--- a/roles/dotfiles/files/.gitconfig
+++ b/roles/dotfiles/files/.gitconfig
@@ -34,8 +34,14 @@
 	# Equivalent to `git graph --all --simplify-by-decoration.
 	sl = log --graph --pretty=format:'%C(auto)%h%Creset%C(auto)%d%Creset %s %C(magenta bold)(%cr)%Creset %C(cyan)<%aN>%Creset' --all --simplify-by-decoration
 
-  # Remove local branches that have merged
+	# Remove local branches that have merged
 	sweep = !sh -c '`brew --prefix git-clean`/bin/git-clean -l'
+
+	# inspired by: https://stackoverflow.com/questions/16203562/programmatically-swap-last-two-commits
+	# flip-down [commitish] [branch]
+	flip-down = "!git rebase --quiet --onto \"$1\"~2 \"$1\"~1 \"$1\"; git cherry-pick \"$1\"~1; git rebase --quiet HEAD \"$2\"; git update-ref refs/heads/\"$2\" $(git rev-parse HEAD); git checkout --quiet \"$2\" #"
+	# flip-up [commitish] [branch]
+	flip-up = "!child=$(git rev-list --ancestry-path \"$1\"..master | tail -1); git flip-down $child \"$2\" #"
 
 [branch]
 	autosetupmerge = always

--- a/roles/dotfiles/files/.tigrc
+++ b/roles/dotfiles/files/.tigrc
@@ -80,8 +80,14 @@ bind generic cc !git commit -v
 bind generic cS !git commit -v -S
 bind generic ca !?@git commit --amend --no-edit
 
-bind generic K view-help
+bind generic H view-help
 bind generic <C-w><C-w> view-next
+
+# Custom commands
+bind main e !git reword %(commit)
+bind main f !@git fixup %(commit)
+bind main J ?@git flip-down %(commit)
+bind main K ?@git flip-up %(commit)
 
 #
 # Color

--- a/roles/dotfiles/files/bin/git-fixup
+++ b/roles/dotfiles/files/bin/git-fixup
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Usage: git-fixup TARGET
+# Squash the commit with its parent commit
+
+TARGET=$(git rev-parse $1)
+PARENT=$(git rev-parse $1^)
+HEAD=$(git rev-parse HEAD)
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+STASHED_CHANGES=false
+
+# Stash local state
+if [[ `git status --porcelain` ]]; then
+  git stash save --include-untracked
+  STASHED_CHANGES=true
+fi
+
+# Reword the commit message with special fixup message
+git checkout --quiet $TARGET
+git commit --quiet --amend -m "fixup! $PARENT"
+
+# Silent interactive rebase
+# Interactive rebase with fixup commit
+# - autosquash: automatically reorder fixup commit to desired location
+# - EDITOR=true: don't open rebase in editor
+# - autostash: push and pop unstaged changes during rebase
+EDITOR=true git rebase $PARENT^ -i --autosquash
+
+# Replay child commits onto the squashed commit
+git rebase --quiet --onto HEAD $TARGET $HEAD
+
+# Update master to reference new head and checkout
+if [ "$BRANCH" != "HEAD" ]; then
+  git update-ref refs/heads/$BRANCH HEAD
+  git checkout --quiet $BRANCH
+fi
+
+# Set ORIG_HEAD so that we can revert
+echo $HEAD > $(git rev-parse --git-dir)/ORIG_HEAD
+
+# Restore working state
+if [ "$STASHED_CHANGES" = true ]; then
+  git stash pop
+fi

--- a/roles/dotfiles/files/bin/git-flip-down
+++ b/roles/dotfiles/files/bin/git-flip-down
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Usage: git flip-down COMMIT
+# Swap the commit with its parent
+
+TARGET=$(git rev-parse $1)
+HEAD=$(git rev-parse HEAD)
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+STASHED_CHANGES=false
+
+# Stash local state
+if [[ `git status --porcelain` ]]; then
+  git stash save --quiet --include-untracked
+  STASHED_CHANGES=true
+fi
+
+# Rebase our target commit on to the parent commits parent
+if ! git rebase --quiet --onto $TARGET~2 $TARGET~1 $TARGET; then
+
+  # Abort if we can't get a clean rebase
+  git rebase --abort
+  exit 1
+
+fi
+
+# Cherry pick the parent commit so that it becomes the child of the target commit
+git cherry-pick $TARGET~1
+
+# Replay commits onto new base
+git rebase --quiet --onto HEAD $TARGET $HEAD
+
+# Set ORIG_HEAD so that we can revert
+echo $HEAD > $(git rev-parse --git-dir)/ORIG_HEAD
+
+# Update master to reference new head and checkout
+if [ "$BRANCH" != "HEAD" ]; then
+  git update-ref refs/heads/$BRANCH HEAD
+  git checkout --quiet $BRANCH
+fi
+
+# TODO: feedback

--- a/roles/dotfiles/files/bin/git-flip-up
+++ b/roles/dotfiles/files/bin/git-flip-up
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Usage: git-flip-up COMMIT
+# Swap the commit with it's child
+
+PARENT=$(git rev-parse $1)
+TARGET=$(git rev-list --ancestry-path $PARENT..master | tail -1)
+
+git flip-down $TARGET
+
+# TODO: feedback

--- a/roles/dotfiles/files/bin/git-reword
+++ b/roles/dotfiles/files/bin/git-reword
@@ -1,0 +1,40 @@
+#!/bin/sh
+# Usage: git-reword TARGET
+# Amend the commit message of an arbitrary commit
+
+TARGET=$(git rev-parse $1)
+HEAD=$(git rev-parse HEAD)
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+STASHED_CHANGES=false
+
+# Stash local state
+if [[ `git status --porcelain` ]]; then
+  git stash save --quiet --include-untracked
+  STASHED_CHANGES=true
+fi
+
+git checkout --quiet $TARGET
+
+# Amend the commit message
+git commit --quiet --amend
+
+NEW_COMMIT=$(git rev-parse HEAD)
+
+# Replay commits onto new base
+git rebase --quiet --onto HEAD $TARGET $HEAD
+
+# Update master to reference new head and checkout
+if [ "$BRANCH" != "HEAD" ]; then
+  git update-ref refs/heads/$BRANCH HEAD
+  git checkout --quiet $BRANCH
+fi
+
+# Set ORIG_HEAD so that we can revert
+echo $HEAD > $(git rev-parse --git-dir)/ORIG_HEAD
+
+# TODO: undo history
+
+# Restore working state
+if [ "$STASHED_CHANGES" = true ]; then
+  git stash pop --quiet
+fi

--- a/roles/dotfiles/files/bin/git-rewrite
+++ b/roles/dotfiles/files/bin/git-rewrite
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Usage: git-rewrite TARGET
+# Rewrite arbitrary commit
+
+TARGET=$(git rev-parse $1)
+TARGET_SHORT=$(git rev-parse --short $1)
+
+GIT_SEQUENCE_EDITOR="sed -i '' 's/^pick $TARGET_SHORT /edit $TARGET_SHORT /'" git rebase -i $TARGET~1
+

--- a/roles/dotfiles/files/bin/git-undo
+++ b/roles/dotfiles/files/bin/git-undo
@@ -1,0 +1,16 @@
+#!/bin/bash
+# References:
+# - https://stackoverflow.com/questions/13804967/bash-pop-lines-in-a-file
+HISTORY="$(git rev-parse --show-toplevel)/.git/MY_HISTORY"
+
+if [ -f "$HISTORY" ]; then
+  STATE=$(sed -i '' -e \$$'{w/dev/stdout\n;d;}' $HISTORY)
+  if [ "$STATE" = "" ]; then
+    echo "Nothing to undo"
+    exit 1
+  fi
+
+  # TODO: determin format of history
+  # <commit> <branch name>
+  echo $STATE
+fi


### PR DESCRIPTION
Command line scripts/aliases for:

- swapping commits (e.g `flip-up` and `flip-down`)

    The crux is `git rebase --quiet --onto $TARGET~2 $TARGET~1 $TARGET` – see `bin/git-flip-down`, `flip-up` is just the reverse case.

- fixing commits (e.g. squash but take the commit message of parent)

    Essentially rewriting the commit message so it's a fixup commit, then running headless interactive rebase. – see `bin/git-fixup`

- squash commits (requires combining commit message)
- split commits (TBD)
- undo (so I don't need to use reflog to undo this madness)